### PR TITLE
README: add instructions regarding deb packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ to the commit message, push the branch and [initiate a pull request](https://hel
 
     git commit --amend
     git push --set-upstream origin ntp
+
+Packaging
+=========
+
+To create a debian package, run `dpkg-buildpackage -us -uc`. You will find the
+packages in the parent directory of your current working directory.


### PR DESCRIPTION
This is a test to ensure that Jenkins can build pull requests for this repository.
