### PR TITLE
debian: rm "files" file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/debian/files

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-takora_0.1.1-1_all.deb misc optional


### PR DESCRIPTION
This file is auto-generated by `dpkg-buildpackage`. Remove it from the git tree. Add its name to `.gitignore` so we don't accidentally check it back in.
